### PR TITLE
flashimage: remove unnecessary ord()

### DIFF
--- a/dumpflash/ecc.py
+++ b/dumpflash/ecc.py
@@ -49,7 +49,7 @@ class Calculator:
         p4 = 0
         p4_ = 0
         for i in range(0, len(body), 1):
-            ch = ord(body[i])
+            ch = body[i]
             bit0 = ch & 0x1
             bit1 = (ch >> 1) & 0x1
             bit2 = (ch >> 2) & 0x1

--- a/dumpflash/flashimage.py
+++ b/dumpflash/flashimage.py
@@ -70,9 +70,9 @@ class IO:
 
             count += 1
             body = data[0:self.SrcImage.PageSize]
-            oob_ecc0 = ord(data[self.SrcImage.PageSize])
-            oob_ecc1 = ord(data[self.SrcImage.PageSize+1])
-            oob_ecc2 = ord(data[self.SrcImage.PageSize+2])
+            oob_ecc0 = data[self.SrcImage.PageSize]
+            oob_ecc1 = data[self.SrcImage.PageSize+1]
+            oob_ecc2 = data[self.SrcImage.PageSize+2]
 
             if (oob_ecc0 == 0xff and oob_ecc1 == 0xff and oob_ecc2 == 0xff) or (oob_ecc0 == 0x00 and oob_ecc1 == 0x00 and oob_ecc2 == 0x00):
                 continue


### PR DESCRIPTION
When running with an image file there is an error in the call to `ord()` on the body:

```
% python3 dumpflash.py -i raw.rom -P 0x2000 -O 64 --bp 64 -c check_ecc
PageSize: 0x2000
OOBSize: 0x40
PagePerBlock: 0x40
BlockSize: 0x80000
RawPageSize: 0x2040
FileSize: 0x10800000
PageCount: 0x8400

Traceback (most recent call last):
  File "dumpflash.py", line 160, in <module>
    flash_image_io.check_ecc()
  File "/home/hudson/sec/nand/dumpflash/dumpflash/flashimage.py", line 73, in check_ecc
    oob_ecc0 = ord(data[self.SrcImage.PageSize])
TypeError: ord() expected string of length 1, but int found
```

Fixing that one produces another error in the ecc; I can't verify if this change breaks the ftdi interface:

```
% python3 dumpflash.py -i raw.rom -P 0x2000 -O 64 --bp 64 -c check_ecc
PageSize: 0x2000
OOBSize: 0x40
PagePerBlock: 0x40
BlockSize: 0x80000
RawPageSize: 0x2040
FileSize: 0x10800000
PageCount: 0x8400

Traceback (most recent call last):
  File "dumpflash.py", line 160, in <module>
    flash_image_io.check_ecc()
  File "/home/hudson/sec/nand/dumpflash/dumpflash/flashimage.py", line 80, in check_ecc
    (ecc0, ecc1, ecc2) = ecc_calculator.calc(body)
  File "/home/hudson/sec/nand/dumpflash/dumpflash/ecc.py", line 52, in calc
    ch = ord(body[i])
TypeError: ord() expected string of length 1, but int found
```